### PR TITLE
Bump opencv and use only the necessary modules to speed up building

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ clap = { version = "4.2.1", features = ["derive"] }
 crossterm = "0.26.1"
 gif = "0.12.0"
 image = "0.24.6"
-opencv = "0.80"
+opencv = { version = "0.82", features = ["videoio", "imgproc", "clang-runtime"] }
 thiserror = "1.0.40"
 fast_image_resize = "2.7.0"
 youtube_dl = "0.8.0"


### PR DESCRIPTION
Hi, I'm suggesting this change to improve the build times and it should also help with this issue in the `opencv` repo: https://github.com/twistedfall/opencv-rust/issues/458