### PR TITLE
Update opencv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ clap = { version = "4.2", features = ["derive"] }
 crossterm = "0.26"
 gif = "0.12"
 image = "0.24"
-opencv = { version = "0.82", default-features = false, features = [
+opencv = { version = "0.84.4", default-features = false, features = [
     "videoio",
     "imgproc",
     "clang-runtime",


### PR DESCRIPTION
cause of bruh:
error[E0119]: conflicting implementations of trait `Debug` for type `RotatedRect`
     --> /tmp/cargo-install7T96lU/release/build/opencv-e9149601bb61141a/out/opencv/core.rs:17920:24
      |
17920 |     #[derive(Copy, Clone, Debug, PartialEq)]
      |                           ^^^^^ conflicting implementation for `RotatedRect`
      |
     ::: /home/dp0sk/.cargo/registry/src/index.crates.io-6f17d22bba15001f/opencv-0.82.1/src/manual/core/rect.rs:277:1
      |
277   | impl fmt::Debug for RotatedRect {
      | ------------------------------- first implementation here
      |
      = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0119`. error: could not compile `opencv` (lib) due to previous error error: failed to compile `tplay v0.4.4`, intermediate artifacts can be found at `/tmp/cargo-install7T96lU`