### PR TITLE
Support looping playback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,9 +187,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
@@ -557,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-next"
-version = "6.0.0"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af03c47ad26832ab3aabc4cdbf210af3d3b878783edd5a7ba044ba33aab7a60"
+checksum = "4e72c72e8dcf638fb0fb03f033a954691662b5dabeaa3f85a6607d101569fccd"
 dependencies = [
  "bitflags 1.3.2",
  "ffmpeg-sys-next",
@@ -568,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-sys-next"
-version = "6.0.1"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf650f461ccf130f4eef4927affed703cc387b183bfc4a7dfee86a076c131127"
+checksum = "c2529ad916d08c3562c754c21bc9b17a26c7882c0f5706cc2cd69472175f1620"
 dependencies = [
  "bindgen",
  "cc",

--- a/src/audio/mpv_player.rs
+++ b/src/audio/mpv_player.rs
@@ -130,4 +130,11 @@ impl AudioPlayerControls for MpvAudioPlayer {
             .command("stop", &["false"])
             .map_err(|err| MyError::Audio(format!("{:?}", err)))
     }
+
+    fn rewind(&mut self) -> Result<(), MyError> {
+        // TODO
+        Err(MyError::Audio(
+            "Rewind feature not implemented for MPV audio player".to_string(),
+        ))
+    }
 }

--- a/src/audio/player.rs
+++ b/src/audio/player.rs
@@ -29,5 +29,6 @@ pub trait AudioPlayerControls {
     fn toggle_play(&mut self) -> Result<(), MyError>;
     fn mute(&mut self) -> Result<(), MyError>;
     fn unmute(&mut self) -> Result<(), MyError>;
+    fn rewind(&mut self) -> Result<(), MyError>;
     fn toggle_mute(&mut self) -> Result<(), MyError>;
 }

--- a/src/audio/rodio_player.rs
+++ b/src/audio/rodio_player.rs
@@ -39,7 +39,11 @@ impl RodioAudioPlayer {
         let player: rodio::Sink = stream_handle
             .play_once(buf)
             .map_err(|err| MyError::Audio(format!("Failed to start playback: {:?}", err)))?;
-        Ok(Self { player, _stream, content })
+        Ok(Self {
+            player,
+            _stream,
+            content,
+        })
     }
 }
 
@@ -73,7 +77,10 @@ impl AudioPlayerControls for RodioAudioPlayer {
         self.player.clear();
         let input = Cursor::new(self.content.clone());
         let input = rodio::decoder::Decoder::new(input).map_err(|err| {
-            MyError::Audio(format!("Could not set decoder on rewind content: {:?}", err))
+            MyError::Audio(format!(
+                "Could not set decoder on rewind content: {:?}",
+                err
+            ))
         })?;
         self.player.append(input);
         self.player.play();

--- a/src/audio/runner.rs
+++ b/src/audio/runner.rs
@@ -36,6 +36,8 @@ pub struct Runner {
 pub enum Control {
     /// Command to toggle between pause and continue playback.
     PauseContinue,
+    /// Replay the audio
+    Replay,
     /// Command to toggle between mute and unmute.
     MuteUnmute,
     /// Command to stop the playback and exit the Runner.
@@ -70,17 +72,18 @@ impl Runner {
                 recv(self.rx_controls) -> msg => {
                     match msg.unwrap() {
                         Control::PauseContinue => {
-
                             self.state = match self.state {
                                 State::Running => State::Paused,
                                 State::Paused => State::Running,
                                 State::Stopped => State::Stopped,
                             };
                             self.audio_player.player.toggle_play()?;
-
                         },
                         Control::MuteUnmute => {
                             self.audio_player.player.toggle_mute()?;
+                        },
+                        Control::Replay => {
+                            self.audio_player.player.rewind()?;
                         },
                         Control::Exit => {
                             self.state = State::Stopped;

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,9 @@ struct Args {
     /// Force a user-specified FPS
     #[arg(short, long)]
     fps: Option<String>,
+    /// Loop playing of video/gif
+    #[arg(short, long, default_value = "false")]
+    loops: bool,
     /// Custom lookup char table
     #[arg(short, long, default_value = CHARS1)]
     char_map: String,
@@ -112,6 +115,7 @@ impl MediaProcessor {
         fps: Option<f64>,
         tx_frames: crossbeam_channel::Sender<Option<StringInfo>>,
         rx_controls_pipeline: crossbeam_channel::Receiver<PipelineControl>,
+        tx_controls: crossbeam_channel::Sender<MediaControl>,
     ) -> Result<(), MyError> {
         let barrier = Arc::clone(&self.barrier);
         let mut use_fps = DEFAULT_FPS;
@@ -125,6 +129,7 @@ impl MediaProcessor {
         }
         let cmaps = args.char_map.chars().collect();
         let w_mod = args.w_mod;
+        let loops = args.loops;
         let allow_frame_skip = args.allow_frame_skip;
         let new_lines = args.new_lines;
         let handle = thread::spawn(move || -> Result<(), MyError> {
@@ -134,7 +139,9 @@ impl MediaProcessor {
                 use_fps,
                 tx_frames,
                 rx_controls_pipeline,
+                tx_controls,
                 w_mod,
+                loops,
             );
             runner.run(barrier, allow_frame_skip)
         });
@@ -196,10 +203,10 @@ fn main() -> Result<(), MyError> {
         args.input.clone(),
         args.gray,
         rx_frames,
-        tx_controls,
+        tx_controls.clone(),
     )?;
 
-    media_processor.launch_pipeline_thread(&args, media, fps, tx_frames, rx_controls_pipeline)?;
+    media_processor.launch_pipeline_thread(&args, media, fps, tx_frames, rx_controls_pipeline, tx_controls)?;
 
     if let Some(audio) = &audio {
         let title = args.input.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use either::Either;
 use msg::broker::Control as MediaControl;
 use pipeline::{
     char_maps::CHARS1, frames::open_media, frames::FrameIterator, image_pipeline::ImagePipeline,
-    runner::Control as PipelineControl,
+    runner::Control as PipelineControl, runner::RunnerOptions,
 };
 use std::thread;
 use terminal::Terminal;
@@ -36,7 +36,7 @@ struct Args {
     fps: Option<String>,
     /// Loop playing of video/gif
     #[arg(short, long, default_value = "false")]
-    loops: bool,
+    loop_playback: bool,
     /// Custom lookup char table
     #[arg(short, long, default_value = CHARS1)]
     char_map: String,
@@ -129,19 +129,21 @@ impl MediaProcessor {
         }
         let cmaps = args.char_map.chars().collect();
         let w_mod = args.w_mod;
-        let loops = args.loops;
+        let loop_playback = args.loop_playback;
         let allow_frame_skip = args.allow_frame_skip;
         let new_lines = args.new_lines;
         let handle = thread::spawn(move || -> Result<(), MyError> {
             let mut runner = pipeline::runner::Runner::new(
                 ImagePipeline::new(DEFAULT_TERMINAL_SIZE, cmaps, new_lines),
                 media,
-                use_fps,
                 tx_frames,
                 rx_controls_pipeline,
                 tx_controls,
-                w_mod,
-                loops,
+                RunnerOptions {
+                    fps: use_fps,
+                    w_mod,
+                    loop_playback,
+                },
             );
             runner.run(barrier, allow_frame_skip)
         });
@@ -206,7 +208,14 @@ fn main() -> Result<(), MyError> {
         tx_controls.clone(),
     )?;
 
-    media_processor.launch_pipeline_thread(&args, media, fps, tx_frames, rx_controls_pipeline, tx_controls)?;
+    media_processor.launch_pipeline_thread(
+        &args,
+        media,
+        fps,
+        tx_frames,
+        rx_controls_pipeline,
+        tx_controls,
+    )?;
 
     if let Some(audio) = &audio {
         let title = args.input.clone();

--- a/src/msg/broker.rs
+++ b/src/msg/broker.rs
@@ -15,6 +15,8 @@ use crossbeam_channel::{select, Receiver, Sender};
 pub enum Control {
     /// Command to toggle between pause and continue playback.
     PauseContinue,
+    /// Replay the sources
+    Replay,
     /// Command to stop the playback and exit the Runner.
     Exit,
     /// Command to toggle between mute and unmute.
@@ -93,6 +95,14 @@ impl MessageBroker {
                             }
                             if let Some(tx) = &self.tx_channel_audio {
                                 let _ = tx.send(AudioControl::PauseContinue);
+                            }
+                        }
+                        Ok(BrokerControl::Replay) => {
+                            if let Some(tx) = &self.tx_channel_pipeline {
+                                let _ = tx.send(PipelineControl::Replay);
+                            }
+                            if let Some(tx) = &self.tx_channel_audio {
+                                let _ = tx.send(AudioControl::Replay);
                             }
                         }
                         Ok(BrokerControl::Resize(width, height)) => {

--- a/src/pipeline/frames.rs
+++ b/src/pipeline/frames.rs
@@ -70,9 +70,12 @@ impl Iterator for FrameIterator {
                 ref frames,
                 ref mut current_frame,
             } => {
-                let frame = frames.get(*current_frame).cloned();
-                *current_frame = (*current_frame + 1) % frames.len();
-                frame
+                if *current_frame == frames.len() - 1 {
+                    None
+                } else {
+                    *current_frame += 1;
+                    frames.get(*current_frame).cloned()
+                }
             }
         }
     }
@@ -106,6 +109,23 @@ impl FrameIterator {
                 frames,
             } => {
                 *current_frame = (*current_frame + n) % frames.len();
+            }
+        }
+    }
+
+    pub fn reset(&mut self) {
+        match self {
+            FrameIterator::Image(_) => {
+                // For a single image, reset is a no-op, since there's only one frame
+            }
+            FrameIterator::Video(ref mut video) => {
+                let _ = video.set(opencv::videoio::CAP_PROP_POS_AVI_RATIO, 0.0);
+            }
+            FrameIterator::AnimatedGif {
+                ref mut current_frame,
+                ..
+            } => {
+                *current_frame = 0;
             }
         }
     }


### PR DESCRIPTION
Thanks @december1981  for adding this feature.  I make a couple of tweaks:
1) Implemented a stub "rewind" in case MPV is used. The audio won't loop but at least it will build.
2) Consolidated runner options in one structure
3) Renamed loops to loop_playback. I'm sad we can't use the "loop" keyword so I opted for more clarity/verboseness, I hope you don't mind!