### PR TITLE
fix for yt-dlp cookies issue 

### DIFF
--- a/src/downloader/youtube.rs
+++ b/src/downloader/youtube.rs
@@ -44,7 +44,11 @@ See https://github.com/yt-dlp/yt-dlp/wiki/Installation"
         .tempfile()?;
 
     let mut cmd = Command::new("yt-dlp");
-    cmd.arg(url)
+    cmd.arg(url)        
+        .arg("--cookies-from-browser") // Required by youtube
+        .arg("firefox") // Change to your browser 
+                        // Supported browsers are: brave, chrome, chromium, edge, firefox, opera, safari, vivaldi, whale
+
         .arg("-o")
         .arg("-")
         .stdout(Stdio::from(temp_file.as_file().try_clone()?));

--- a/src/downloader/youtube.rs
+++ b/src/downloader/youtube.rs
@@ -27,7 +27,7 @@ use tempfile::{self, TempPath};
 /// * `yt-dlp` is not installed on the system.
 /// * The video download fails for any reason.
 /// * There is an issue with creating or writing to the temporary file.
-pub fn download_video(url: &str) -> Result<TempPath, MyError> {
+pub fn download_video(url: &str, browser: &str) -> Result<TempPath, MyError> {
     // Check that yt-dlp is installed
     if Command::new("yt-dlp").output().is_err() {
         return Err(MyError::Application(
@@ -46,7 +46,7 @@ See https://github.com/yt-dlp/yt-dlp/wiki/Installation"
     let mut cmd = Command::new("yt-dlp");
     cmd.arg(url)        
         .arg("--cookies-from-browser") // Required by youtube
-        .arg("firefox") // Change to your browser 
+        .arg(browser) // from cli now --browser <BROWSER> 
                         // Supported browsers are: brave, chrome, chromium, edge, firefox, opera, safari, vivaldi, whale
 
         .arg("-o")

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,9 @@ struct Args {
     /// Force a user-specified FPS
     #[arg(short, long)]
     fps: Option<String>,
+    /// import YT cookies from browser (default: firefox) 
+    #[arg(short, long, required= false)]
+    browser: Option<String>,
     /// Loop playing of video/gif
     #[arg(short, long, default_value = "false")]
     loop_playback: bool,
@@ -56,6 +59,7 @@ struct Args {
 
 const DEFAULT_TERMINAL_SIZE: (u32, u32) = (80, 24);
 const DEFAULT_FPS: f64 = 30.0;
+const DEFAULT_BROWSER: &str = "firefox";
 
 use std::sync::{Arc, Barrier};
 use std::thread::JoinHandle;
@@ -177,8 +181,9 @@ fn main() -> Result<(), MyError> {
     let args = Args::parse();
 
     let title = args.input.clone();
+    let browser = if args.browser.clone().is_some() { args.browser.clone().unwrap() } else { String::from(DEFAULT_BROWSER) };
 
-    let media_data = open_media(title)?;
+    let media_data = open_media(title, browser)?;
     let media = media_data.frame_iter;
     let fps = media_data.fps;
     let audio = media_data.audio_path;

--- a/src/pipeline/frames.rs
+++ b/src/pipeline/frames.rs
@@ -147,13 +147,13 @@ impl FrameIterator {
 ///
 /// A `Result` containing a `FrameData` struct if the media file is successfully opened, or a
 /// `MyError` if an error occurs.
-pub fn open_media(path: String) -> Result<MediaData, MyError> {
+pub fn open_media(path: String, broswer: String) -> Result<MediaData, MyError> {
     // Check if the path is a URL
     if let Ok(url) = Url::parse(path.as_str()) {
         if let Some(domain) = url.domain() {
             // handle YouTube domains specially
             if domain.ends_with("youtube.com") || domain.ends_with("youtu.be") {
-                let video = youtube::download_video(path.as_str())?;
+                let video = youtube::download_video(path.as_str(), broswer.as_str())?;
                 let fps = extract_fps(video.as_os_str().to_str().unwrap_or(""));
                 let video_open = open_video(&video)?;
                 return Ok(MediaData {


### PR DESCRIPTION
quick fix for this issue: https://github.com/maxcurzi/tplay/issues/54

After first commit, users need to change the code "src/downloader/youtube.rs" if they want to import cookies from a browser other than firefox.

In second commit, I added handling --browser <BROSWER> option via arguments.