### PR TITLE
pipeline: fix open_media usage

### DIFF
--- a/src/pipeline/runner.rs
+++ b/src/pipeline/runner.rs
@@ -427,7 +427,7 @@ mod tests {
     fn test_time_to_send_next_frame() {
         let fps = 23.976;
         let loop_playback = false;
-        let media_data = open_media(MEDIA_FILE.to_string()).unwrap();
+        let media_data = open_media(MEDIA_FILE.to_string(), crate::DEFAULT_BROWSER.to_string()).unwrap();
         let media = media_data.frame_iter;
         let pipeline = ImagePipeline::new((23, 80), CHARS1.chars().collect(), false);
 


### PR DESCRIPTION
This seems to fix tests.

Fixes: #58