### PR TITLE
Charset 3 is now half-block render mode. Crazy high fideility for ascii.

### DIFF
--- a/src/pipeline/char_maps.rs
+++ b/src/pipeline/char_maps.rs
@@ -26,3 +26,7 @@ pub const GRADIENT: &str = r#" ░▒▓█"#; // 5 chars
 pub const BLACKWHITE: &str = r#" █"#; // 2 chars
 pub const BW_DOTTED: &str = r#" ⣿"#; // 2 dotted block
 pub const BRAILLE: &str = r#" ··⣀⣀⣤⣤⣤⣀⡀⢀⠠⠔⠒⠑⠊⠉⠁"#; // 16 chars (braille-based)
+
+// Half-block mode marker — used to signal half-block rendering (▀ with fg+bg colors)
+// Doubles vertical resolution by encoding 2 pixel rows per terminal row
+pub const HALFBLOCK: &str = "▀";

--- a/src/pipeline/image_pipeline.rs
+++ b/src/pipeline/image_pipeline.rs
@@ -21,6 +21,8 @@ pub struct ImagePipeline {
     lut: [char; 256],
     /// Use smooth (CatmullRom) downscaling instead of nearest-neighbor
     pub smooth_resize: bool,
+    /// Half-block mode: uses ▀ with fg+bg colors for 2x vertical resolution
+    pub half_block_mode: bool,
 }
 
 impl ImagePipeline {
@@ -41,6 +43,7 @@ impl ImagePipeline {
             new_lines,
             lut,
             smooth_resize: false,
+            half_block_mode: false,
         }
     }
 
@@ -194,6 +197,53 @@ impl ImagePipeline {
         }
 
         output
+    }
+    /// Converts RGB pixel data to half-block characters (▀) with 2x vertical resolution.
+    /// Each terminal cell represents 2 vertical pixels using foreground and background colors.
+    /// Returns (string of ▀ characters, rgb_data with 6 bytes per cell: top_rgb + bottom_rgb).
+    pub fn to_half_blocks_from_rgb(
+        &self,
+        rgb_data: &[u8],
+        width: u32,
+        height: u32,
+    ) -> (String, Vec<u8>) {
+        let out_height = height / 2;
+        let capacity = (width as usize + 1) * out_height as usize;
+        let mut output = String::with_capacity(capacity);
+        // 6 bytes per cell: 3 for top pixel (foreground), 3 for bottom pixel (background)
+        let mut rgb_out = Vec::with_capacity(capacity * 6);
+
+        for y in (0..height).step_by(2) {
+            let top_row_start = (y * width * 3) as usize;
+            let bot_row_start = if y + 1 < height {
+                ((y + 1) * width * 3) as usize
+            } else {
+                top_row_start // duplicate last row if odd height
+            };
+
+            for x in 0..width as usize {
+                let top_idx = top_row_start + x * 3;
+                let bot_idx = bot_row_start + x * 3;
+
+                output.push('▀');
+
+                // Top pixel RGB (foreground)
+                rgb_out.push(rgb_data[top_idx]);
+                rgb_out.push(rgb_data[top_idx + 1]);
+                rgb_out.push(rgb_data[top_idx + 2]);
+                // Bottom pixel RGB (background)
+                rgb_out.push(rgb_data[bot_idx]);
+                rgb_out.push(rgb_data[bot_idx + 1]);
+                rgb_out.push(rgb_data[bot_idx + 2]);
+            }
+
+            if self.new_lines && y + 2 < height {
+                output.push('\r');
+                output.push('\n');
+            }
+        }
+
+        (output, rgb_out)
     }
 }
 

--- a/src/pipeline/runner.rs
+++ b/src/pipeline/runner.rs
@@ -128,7 +128,7 @@ impl Runner {
             pipeline.char_map.clone(),
             CHARS1.to_string().chars().collect(),
             CHARS2.to_string().chars().collect(),
-            CHARS3.to_string().chars().collect(),
+            HALFBLOCK.to_string().chars().collect(), // 3: half-block (2x vertical resolution)
             SOLID.to_string().chars().collect(),
             DOTTED.to_string().chars().collect(),
             GRADIENT.to_string().chars().collect(),
@@ -234,6 +234,13 @@ impl Runner {
         let (width, height) = (rgb_image.width(), rgb_image.height());
         let rgb_info = rgb_image.into_raw();
 
+        if self.pipeline.half_block_mode {
+            let (ascii, rgb_data) =
+                self.pipeline.to_half_blocks_from_rgb(&rgb_info, width, height);
+            let (ascii, rgb_data) = self.pad_to_terminal_halfblock(ascii, rgb_data, width, height / 2);
+            return Ok((ascii, rgb_data));
+        }
+
         let ascii = self.pipeline.to_ascii_from_rgb(&rgb_info, width, height);
 
         // Add newlines to the rgb_info to match the ascii string These are not
@@ -302,6 +309,62 @@ impl Runner {
                 for _ in 0..term_w {
                     padded_ascii.push(' ');
                     padded_rgb.extend_from_slice(&[0, 0, 0]);
+                }
+            }
+        }
+
+        (padded_ascii, padded_rgb)
+    }
+
+    /// Pads half-block output to the terminal dimensions.
+    /// Half-block RGB data uses 6 bytes per cell (fg_rgb + bg_rgb).
+    fn pad_to_terminal_halfblock(
+        &self,
+        ascii: String,
+        rgb: Vec<u8>,
+        img_w: u32,
+        img_h: u32,
+    ) -> (String, Vec<u8>) {
+        let img_w = img_w as usize;
+        let img_h = img_h as usize;
+        let term_w = self.terminal_cols as usize;
+        let term_h = self.terminal_rows as usize;
+
+        if img_w == term_w && img_h == term_h {
+            return (ascii, rgb);
+        }
+
+        let x_offset = (term_w.saturating_sub(img_w)) / 2;
+        let y_offset = (term_h.saturating_sub(img_h)) / 2;
+
+        let mut padded_ascii = String::with_capacity(term_w * term_h);
+        let mut padded_rgb = Vec::with_capacity(term_w * term_h * 6);
+        let ascii_chars: Vec<char> = ascii.chars().collect();
+
+        for row in 0..term_h {
+            let img_row = row.wrapping_sub(y_offset);
+            if row >= y_offset && img_row < img_h {
+                let start = img_row * img_w;
+                let end = (start + img_w).min(ascii_chars.len());
+                let written = end - start;
+                // Left padding
+                for _ in 0..x_offset {
+                    padded_ascii.push(' ');
+                    padded_rgb.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+                }
+                // Image content
+                padded_ascii.extend(&ascii_chars[start..end]);
+                padded_rgb.extend_from_slice(&rgb[start * 6..end * 6]);
+                // Right padding
+                for _ in (x_offset + written)..term_w {
+                    padded_ascii.push(' ');
+                    padded_rgb.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+                }
+            } else {
+                // Blank row
+                for _ in 0..term_w {
+                    padded_ascii.push(' ');
+                    padded_rgb.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
                 }
             }
         }
@@ -413,6 +476,13 @@ impl Runner {
                 (term_w, term_h)
             };
 
+        // In half-block mode, we need 2x the pixel height since each terminal row
+        // represents 2 vertical pixels
+        let target_h = if self.pipeline.half_block_mode {
+            target_h * 2
+        } else {
+            target_h
+        };
         let _ = self.pipeline.set_target_resolution(target_w, target_h);
     }
 
@@ -422,9 +492,13 @@ impl Runner {
     ///
     /// * `char_map` - The index of the character map to use.
     fn set_char_map(&mut self, char_map: u32) {
-        self.pipeline.char_map =
-            self.char_maps[(char_map % self.char_maps.len() as u32) as usize].clone();
+        let idx = (char_map % self.char_maps.len() as u32) as usize;
+        self.pipeline.char_map = self.char_maps[idx].clone();
+        self.pipeline.half_block_mode = idx == 3; // index 3 = HALFBLOCK
         self.pipeline.rebuild_lut();
+
+        // Re-trigger resize so half_block_mode's 2x height is applied (or reverted)
+        self.resize_pipeline(self.terminal_cols as u16, self.terminal_rows as u16);
     }
 
     /// Determines if a frame should be processed based on the current time and the Runner's state.

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -214,6 +214,14 @@ impl Terminal {
     fn draw(&mut self, (string, rgb_data): &StringInfo) -> IOResult<()> {
         use std::fmt::Write;
 
+        // Detect half-block mode: 6 bytes per character instead of 3
+        let char_count = string.chars().filter(|c| *c != '\r' && *c != '\n').count();
+        let is_halfblock = char_count > 0 && rgb_data.len() == char_count * 6;
+
+        if is_halfblock {
+            return self.draw_halfblock(string, rgb_data);
+        }
+
         let can_delta = self.prev_rgb.len() == rgb_data.len() && !rgb_data.is_empty();
 
         if can_delta {
@@ -300,6 +308,107 @@ impl Terminal {
         self.prev_rgb.clear();
         self.prev_rgb.extend_from_slice(rgb_data);
 
+        Ok(())
+    }
+
+    /// Draws a half-block frame with foreground + background colors per cell.
+    /// RGB data format: 6 bytes per cell (fg_r, fg_g, fg_b, bg_r, bg_g, bg_b).
+    fn draw_halfblock(&mut self, string: &str, rgb_data: &[u8]) -> IOResult<()> {
+        use std::fmt::Write;
+
+        let term_w = self.terminal_width as usize;
+        let can_delta = self.prev_rgb.len() == rgb_data.len() && !rgb_data.is_empty();
+
+        if can_delta {
+            // Delta render for half-block — mirrors the original delta renderer's
+            // cursor_at pattern for proven performance characteristics
+            let mut buf = String::with_capacity(string.len() * 8);
+            let mut last_fg: Option<[u8; 3]> = None;
+            let mut last_bg: Option<[u8; 3]> = None;
+            let mut cursor_at: Option<usize> = None;
+
+            for (i, _c) in string.chars().filter(|c| *c != '\r' && *c != '\n').enumerate() {
+                let rgb_off = i * 6;
+                if rgb_off + 5 >= rgb_data.len() {
+                    break;
+                }
+
+                let fg = &rgb_data[rgb_off..rgb_off + 3];
+                let bg = &rgb_data[rgb_off + 3..rgb_off + 6];
+                let prev_fg = &self.prev_rgb[rgb_off..rgb_off + 3];
+                let prev_bg = &self.prev_rgb[rgb_off + 3..rgb_off + 6];
+
+                if fg == prev_fg && bg == prev_bg {
+                    continue;
+                }
+
+                // Position cursor if not already there, or at row boundary
+                if cursor_at != Some(i) || (term_w > 0 && i % term_w == 0) {
+                    let _ = write!(buf, "\x1b[{};{}H", i / term_w + 1, i % term_w + 1);
+                    last_fg = None;
+                    last_bg = None;
+                }
+
+                let fg_color = [fg[0], fg[1], fg[2]];
+                let bg_color = [bg[0], bg[1], bg[2]];
+
+                if last_fg != Some(fg_color) || last_bg != Some(bg_color) {
+                    let _ = write!(
+                        buf,
+                        "\x1b[38;2;{};{};{};48;2;{};{};{}m▀",
+                        fg[0], fg[1], fg[2], bg[0], bg[1], bg[2]
+                    );
+                    last_fg = Some(fg_color);
+                    last_bg = Some(bg_color);
+                } else {
+                    buf.push('▀');
+                }
+
+                cursor_at = Some(i + 1);
+            }
+
+            if !buf.is_empty() {
+                buf.push_str("\x1b[0m");
+                let mut out = stdout();
+                out.write_all(buf.as_bytes())?;
+                out.flush()?;
+            }
+        } else {
+            // Full redraw for half-block
+            let mut colored = String::with_capacity(string.len() * 30);
+            let mut cell_idx = 0;
+
+            for c in string.chars() {
+                if c == '\r' || c == '\n' {
+                    continue;
+                }
+
+                let rgb_off = cell_idx * 6;
+                if rgb_off + 5 >= rgb_data.len() {
+                    break;
+                }
+
+                let _ = write!(
+                    colored,
+                    "\x1b[38;2;{};{};{};48;2;{};{};{}m▀",
+                    rgb_data[rgb_off],
+                    rgb_data[rgb_off + 1],
+                    rgb_data[rgb_off + 2],
+                    rgb_data[rgb_off + 3],
+                    rgb_data[rgb_off + 4],
+                    rgb_data[rgb_off + 5]
+                );
+                cell_idx += 1;
+            }
+
+            colored.push_str("\x1b[0m");
+            let mut out = stdout();
+            execute!(out, MoveTo(0, 0), Print(&colored), MoveTo(0, 0))?;
+            out.flush()?;
+        }
+
+        self.prev_rgb.clear();
+        self.prev_rgb.extend_from_slice(rgb_data);
         Ok(())
     }
 


### PR DESCRIPTION
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/83644338-66b4-4ced-8dac-731f0e28f06f" />

This get's double the vertical resolution.  Charset 3 was a duplicate of 0 I believe.  Charset 4 was full block mode, so having 3 adjacent to it with half block mode seemed to make sense.  Screenshot shows max resolution (smallest font) in kitty terminal.  Framerate is still good.  Damn!

High contrast black and white diagonal lines are a great way to stress the resolution test.  Piano keys work great for that and it still looks pretty damn crisp.